### PR TITLE
Enhance chart source selection dialog

### DIFF
--- a/ChartDldrGui.fbp
+++ b/ChartDldrGui.fbp
@@ -107,212 +107,91 @@
                         <event name="OnUpdateUI"></event>
                         <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxEXPAND</property>
-                            <property name="proportion">0</property>
-                            <object class="wxBoxSizer" expanded="1">
-                                <property name="minimum_size"></property>
-                                <property name="name">bSizerType</property>
-                                <property name="orient">wxHORIZONTAL</property>
-                                <property name="permission">none</property>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALL|wxEXPAND</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxRadioButton" expanded="0">
-                                        <property name="BottomDockable">1</property>
-                                        <property name="LeftDockable">1</property>
-                                        <property name="RightDockable">1</property>
-                                        <property name="TopDockable">1</property>
-                                        <property name="aui_layer"></property>
-                                        <property name="aui_name"></property>
-                                        <property name="aui_position"></property>
-                                        <property name="aui_row"></property>
-                                        <property name="best_size"></property>
-                                        <property name="bg"></property>
-                                        <property name="caption"></property>
-                                        <property name="caption_visible">1</property>
-                                        <property name="center_pane">0</property>
-                                        <property name="close_button">1</property>
-                                        <property name="context_help"></property>
-                                        <property name="context_menu">1</property>
-                                        <property name="default_pane">0</property>
-                                        <property name="dock">Dock</property>
-                                        <property name="dock_fixed">0</property>
-                                        <property name="docking">Left</property>
-                                        <property name="enabled">1</property>
-                                        <property name="fg"></property>
-                                        <property name="floatable">1</property>
-                                        <property name="font"></property>
-                                        <property name="gripper">0</property>
-                                        <property name="hidden">0</property>
-                                        <property name="id">wxID_ANY</property>
-                                        <property name="label">Predefined</property>
-                                        <property name="max_size"></property>
-                                        <property name="maximize_button">0</property>
-                                        <property name="maximum_size"></property>
-                                        <property name="min_size"></property>
-                                        <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
-                                        <property name="moveable">1</property>
-                                        <property name="name">m_rbPredefined</property>
-                                        <property name="pane_border">1</property>
-                                        <property name="pane_position"></property>
-                                        <property name="pane_size"></property>
-                                        <property name="permission">protected</property>
-                                        <property name="pin_button">1</property>
-                                        <property name="pos"></property>
-                                        <property name="resize">Resizable</property>
-                                        <property name="show">1</property>
-                                        <property name="size"></property>
-                                        <property name="style"></property>
-                                        <property name="subclass"></property>
-                                        <property name="toolbar_pane">0</property>
-                                        <property name="tooltip"></property>
-                                        <property name="validator_data_type"></property>
-                                        <property name="validator_style">wxFILTER_NONE</property>
-                                        <property name="validator_type">wxDefaultValidator</property>
-                                        <property name="validator_variable"></property>
-                                        <property name="value">0</property>
-                                        <property name="window_extra_style"></property>
-                                        <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <event name="OnChar"></event>
-                                        <event name="OnEnterWindow"></event>
-                                        <event name="OnEraseBackground"></event>
-                                        <event name="OnKeyDown"></event>
-                                        <event name="OnKeyUp"></event>
-                                        <event name="OnKillFocus"></event>
-                                        <event name="OnLeaveWindow"></event>
-                                        <event name="OnLeftDClick"></event>
-                                        <event name="OnLeftDown"></event>
-                                        <event name="OnLeftUp"></event>
-                                        <event name="OnMiddleDClick"></event>
-                                        <event name="OnMiddleDown"></event>
-                                        <event name="OnMiddleUp"></event>
-                                        <event name="OnMotion"></event>
-                                        <event name="OnMouseEvents"></event>
-                                        <event name="OnMouseWheel"></event>
-                                        <event name="OnPaint"></event>
-                                        <event name="OnRadioButton">OnChangeType</event>
-                                        <event name="OnRightDClick"></event>
-                                        <event name="OnRightDown"></event>
-                                        <event name="OnRightUp"></event>
-                                        <event name="OnSetFocus"></event>
-                                        <event name="OnSize"></event>
-                                        <event name="OnUpdateUI"></event>
-                                    </object>
-                                </object>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALL</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxRadioButton" expanded="0">
-                                        <property name="BottomDockable">1</property>
-                                        <property name="LeftDockable">1</property>
-                                        <property name="RightDockable">1</property>
-                                        <property name="TopDockable">1</property>
-                                        <property name="aui_layer"></property>
-                                        <property name="aui_name"></property>
-                                        <property name="aui_position"></property>
-                                        <property name="aui_row"></property>
-                                        <property name="best_size"></property>
-                                        <property name="bg"></property>
-                                        <property name="caption"></property>
-                                        <property name="caption_visible">1</property>
-                                        <property name="center_pane">0</property>
-                                        <property name="close_button">1</property>
-                                        <property name="context_help"></property>
-                                        <property name="context_menu">1</property>
-                                        <property name="default_pane">0</property>
-                                        <property name="dock">Dock</property>
-                                        <property name="dock_fixed">0</property>
-                                        <property name="docking">Left</property>
-                                        <property name="enabled">1</property>
-                                        <property name="fg"></property>
-                                        <property name="floatable">1</property>
-                                        <property name="font"></property>
-                                        <property name="gripper">0</property>
-                                        <property name="hidden">0</property>
-                                        <property name="id">wxID_ANY</property>
-                                        <property name="label">Custom</property>
-                                        <property name="max_size"></property>
-                                        <property name="maximize_button">0</property>
-                                        <property name="maximum_size"></property>
-                                        <property name="min_size"></property>
-                                        <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
-                                        <property name="moveable">1</property>
-                                        <property name="name">m_rbCustom</property>
-                                        <property name="pane_border">1</property>
-                                        <property name="pane_position"></property>
-                                        <property name="pane_size"></property>
-                                        <property name="permission">protected</property>
-                                        <property name="pin_button">1</property>
-                                        <property name="pos"></property>
-                                        <property name="resize">Resizable</property>
-                                        <property name="show">1</property>
-                                        <property name="size"></property>
-                                        <property name="style"></property>
-                                        <property name="subclass"></property>
-                                        <property name="toolbar_pane">0</property>
-                                        <property name="tooltip"></property>
-                                        <property name="validator_data_type"></property>
-                                        <property name="validator_style">wxFILTER_NONE</property>
-                                        <property name="validator_type">wxDefaultValidator</property>
-                                        <property name="validator_variable"></property>
-                                        <property name="value">0</property>
-                                        <property name="window_extra_style"></property>
-                                        <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <event name="OnChar"></event>
-                                        <event name="OnEnterWindow"></event>
-                                        <event name="OnEraseBackground"></event>
-                                        <event name="OnKeyDown"></event>
-                                        <event name="OnKeyUp"></event>
-                                        <event name="OnKillFocus"></event>
-                                        <event name="OnLeaveWindow"></event>
-                                        <event name="OnLeftDClick"></event>
-                                        <event name="OnLeftDown"></event>
-                                        <event name="OnLeftUp"></event>
-                                        <event name="OnMiddleDClick"></event>
-                                        <event name="OnMiddleDown"></event>
-                                        <event name="OnMiddleUp"></event>
-                                        <event name="OnMotion"></event>
-                                        <event name="OnMouseEvents"></event>
-                                        <event name="OnMouseWheel"></event>
-                                        <event name="OnPaint"></event>
-                                        <event name="OnRadioButton">OnChangeType</event>
-                                        <event name="OnRightDClick"></event>
-                                        <event name="OnRightDown"></event>
-                                        <event name="OnRightUp"></event>
-                                        <event name="OnSetFocus"></event>
-                                        <event name="OnSize"></event>
-                                        <event name="OnUpdateUI"></event>
-                                    </object>
-                                </object>
-                            </object>
-                        </object>
-                        <object class="sizeritem" expanded="1">
-                            <property name="border">5</property>
-                            <property name="flag">wxALL|wxEXPAND</property>
+                            <property name="flag">wxEXPAND | wxALL</property>
                             <property name="proportion">1</property>
-                            <object class="wxFlexGridSizer" expanded="1">
-                                <property name="cols">2</property>
-                                <property name="flexible_direction">wxBOTH</property>
-                                <property name="growablecols">1</property>
-                                <property name="growablerows"></property>
-                                <property name="hgap">0</property>
-                                <property name="minimum_size">-1,-1</property>
-                                <property name="name">fgSizerSourceSel</property>
-                                <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
-                                <property name="permission">none</property>
-                                <property name="rows">3</property>
-                                <property name="vgap">0</property>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxStaticText" expanded="0">
+                            <object class="wxNotebook" expanded="1">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="bitmapsize"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size">-1,200</property>
+                                <property name="moveable">1</property>
+                                <property name="name">m_nbChoice</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">public</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="style">wxNB_TOP</property>
+                                <property name="subclass"></property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style"></property>
+                                <event name="OnChar"></event>
+                                <event name="OnEnterWindow"></event>
+                                <event name="OnEraseBackground"></event>
+                                <event name="OnKeyDown"></event>
+                                <event name="OnKeyUp"></event>
+                                <event name="OnKillFocus"></event>
+                                <event name="OnLeaveWindow"></event>
+                                <event name="OnLeftDClick"></event>
+                                <event name="OnLeftDown"></event>
+                                <event name="OnLeftUp"></event>
+                                <event name="OnMiddleDClick"></event>
+                                <event name="OnMiddleDown"></event>
+                                <event name="OnMiddleUp"></event>
+                                <event name="OnMotion"></event>
+                                <event name="OnMouseEvents"></event>
+                                <event name="OnMouseWheel"></event>
+                                <event name="OnNotebookPageChanged"></event>
+                                <event name="OnNotebookPageChanging"></event>
+                                <event name="OnPaint"></event>
+                                <event name="OnRightDClick"></event>
+                                <event name="OnRightDown"></event>
+                                <event name="OnRightUp"></event>
+                                <event name="OnSetFocus"></event>
+                                <event name="OnSize"></event>
+                                <event name="OnUpdateUI"></event>
+                                <object class="notebookpage" expanded="1">
+                                    <property name="bitmap"></property>
+                                    <property name="label">Predefined</property>
+                                    <property name="select">1</property>
+                                    <object class="wxPanel" expanded="1">
                                         <property name="BottomDockable">1</property>
                                         <property name="LeftDockable">1</property>
                                         <property name="RightDockable">1</property>
@@ -340,15 +219,14 @@
                                         <property name="gripper">0</property>
                                         <property name="hidden">0</property>
                                         <property name="id">wxID_ANY</property>
-                                        <property name="label">Catalog</property>
                                         <property name="max_size"></property>
                                         <property name="maximize_button">0</property>
                                         <property name="maximum_size"></property>
                                         <property name="min_size"></property>
                                         <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
+                                        <property name="minimum_size">-1,-1</property>
                                         <property name="moveable">1</property>
-                                        <property name="name">m_stCatalog</property>
+                                        <property name="name">m_panel1</property>
                                         <property name="pane_border">1</property>
                                         <property name="pane_position"></property>
                                         <property name="pane_size"></property>
@@ -358,14 +236,12 @@
                                         <property name="resize">Resizable</property>
                                         <property name="show">1</property>
                                         <property name="size"></property>
-                                        <property name="style"></property>
                                         <property name="subclass"></property>
                                         <property name="toolbar_pane">0</property>
                                         <property name="tooltip"></property>
                                         <property name="window_extra_style"></property>
                                         <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <property name="wrap">-1</property>
+                                        <property name="window_style">wxTAB_TRAVERSAL</property>
                                         <event name="OnChar"></event>
                                         <event name="OnEnterWindow"></event>
                                         <event name="OnEraseBackground"></event>
@@ -389,13 +265,121 @@
                                         <event name="OnSetFocus"></event>
                                         <event name="OnSize"></event>
                                         <event name="OnUpdateUI"></event>
+                                        <object class="wxBoxSizer" expanded="1">
+                                            <property name="minimum_size"></property>
+                                            <property name="name">bSizer8</property>
+                                            <property name="orient">wxVERTICAL</property>
+                                            <property name="permission">none</property>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALL|wxEXPAND</property>
+                                                <property name="proportion">1</property>
+                                                <object class="wxTreeCtrl" expanded="1">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">m_treeCtrl1</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">public</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style">wxTR_DEFAULT_STYLE|wxTR_HIDE_ROOT</property>
+                                                    <property name="subclass"></property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnChar"></event>
+                                                    <event name="OnEnterWindow"></event>
+                                                    <event name="OnEraseBackground"></event>
+                                                    <event name="OnKeyDown"></event>
+                                                    <event name="OnKeyUp"></event>
+                                                    <event name="OnKillFocus"></event>
+                                                    <event name="OnLeaveWindow"></event>
+                                                    <event name="OnLeftDClick"></event>
+                                                    <event name="OnLeftDown"></event>
+                                                    <event name="OnLeftUp"></event>
+                                                    <event name="OnMiddleDClick"></event>
+                                                    <event name="OnMiddleDown"></event>
+                                                    <event name="OnMiddleUp"></event>
+                                                    <event name="OnMotion"></event>
+                                                    <event name="OnMouseEvents"></event>
+                                                    <event name="OnMouseWheel"></event>
+                                                    <event name="OnPaint"></event>
+                                                    <event name="OnRightDClick"></event>
+                                                    <event name="OnRightDown"></event>
+                                                    <event name="OnRightUp"></event>
+                                                    <event name="OnSetFocus"></event>
+                                                    <event name="OnSize"></event>
+                                                    <event name="OnTreeBeginDrag"></event>
+                                                    <event name="OnTreeBeginLabelEdit"></event>
+                                                    <event name="OnTreeBeginRDrag"></event>
+                                                    <event name="OnTreeDeleteItem"></event>
+                                                    <event name="OnTreeEndDrag"></event>
+                                                    <event name="OnTreeEndLabelEdit"></event>
+                                                    <event name="OnTreeGetInfo"></event>
+                                                    <event name="OnTreeItemActivated"></event>
+                                                    <event name="OnTreeItemCollapsed"></event>
+                                                    <event name="OnTreeItemCollapsing"></event>
+                                                    <event name="OnTreeItemExpanded"></event>
+                                                    <event name="OnTreeItemExpanding"></event>
+                                                    <event name="OnTreeItemGetTooltip"></event>
+                                                    <event name="OnTreeItemMenu"></event>
+                                                    <event name="OnTreeItemMiddleClick"></event>
+                                                    <event name="OnTreeItemRightClick"></event>
+                                                    <event name="OnTreeKeyDown"></event>
+                                                    <event name="OnTreeSelChanged">OnSourceSelected</event>
+                                                    <event name="OnTreeSelChanging"></event>
+                                                    <event name="OnTreeSetInfo"></event>
+                                                    <event name="OnTreeStateImageClick"></event>
+                                                    <event name="OnUpdateUI"></event>
+                                                </object>
+                                            </object>
+                                        </object>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALL|wxEXPAND</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxChoice" expanded="0">
+                                <object class="notebookpage" expanded="1">
+                                    <property name="bitmap"></property>
+                                    <property name="label">Custom</property>
+                                    <property name="select">0</property>
+                                    <object class="wxPanel" expanded="1">
                                         <property name="BottomDockable">1</property>
                                         <property name="LeftDockable">1</property>
                                         <property name="RightDockable">1</property>
@@ -409,7 +393,6 @@
                                         <property name="caption"></property>
                                         <property name="caption_visible">1</property>
                                         <property name="center_pane">0</property>
-                                        <property name="choices"></property>
                                         <property name="close_button">1</property>
                                         <property name="context_help"></property>
                                         <property name="context_menu">1</property>
@@ -431,95 +414,7 @@
                                         <property name="minimize_button">0</property>
                                         <property name="minimum_size"></property>
                                         <property name="moveable">1</property>
-                                        <property name="name">m_cbChartSources</property>
-                                        <property name="pane_border">1</property>
-                                        <property name="pane_position"></property>
-                                        <property name="pane_size"></property>
-                                        <property name="permission">public</property>
-                                        <property name="pin_button">1</property>
-                                        <property name="pos"></property>
-                                        <property name="resize">Resizable</property>
-                                        <property name="selection">0</property>
-                                        <property name="show">1</property>
-                                        <property name="size"></property>
-                                        <property name="style"></property>
-                                        <property name="subclass"></property>
-                                        <property name="toolbar_pane">0</property>
-                                        <property name="tooltip"></property>
-                                        <property name="validator_data_type"></property>
-                                        <property name="validator_style">wxFILTER_NONE</property>
-                                        <property name="validator_type">wxDefaultValidator</property>
-                                        <property name="validator_variable"></property>
-                                        <property name="window_extra_style"></property>
-                                        <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <event name="OnChar"></event>
-                                        <event name="OnChoice">OnSourceSelected</event>
-                                        <event name="OnEnterWindow"></event>
-                                        <event name="OnEraseBackground"></event>
-                                        <event name="OnKeyDown"></event>
-                                        <event name="OnKeyUp"></event>
-                                        <event name="OnKillFocus"></event>
-                                        <event name="OnLeaveWindow"></event>
-                                        <event name="OnLeftDClick"></event>
-                                        <event name="OnLeftDown"></event>
-                                        <event name="OnLeftUp"></event>
-                                        <event name="OnMiddleDClick"></event>
-                                        <event name="OnMiddleDown"></event>
-                                        <event name="OnMiddleUp"></event>
-                                        <event name="OnMotion"></event>
-                                        <event name="OnMouseEvents"></event>
-                                        <event name="OnMouseWheel"></event>
-                                        <event name="OnPaint"></event>
-                                        <event name="OnRightDClick"></event>
-                                        <event name="OnRightDown"></event>
-                                        <event name="OnRightUp"></event>
-                                        <event name="OnSetFocus"></event>
-                                        <event name="OnSize"></event>
-                                        <event name="OnUpdateUI"></event>
-                                    </object>
-                                </object>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxStaticText" expanded="0">
-                                        <property name="BottomDockable">1</property>
-                                        <property name="LeftDockable">1</property>
-                                        <property name="RightDockable">1</property>
-                                        <property name="TopDockable">1</property>
-                                        <property name="aui_layer"></property>
-                                        <property name="aui_name"></property>
-                                        <property name="aui_position"></property>
-                                        <property name="aui_row"></property>
-                                        <property name="best_size"></property>
-                                        <property name="bg"></property>
-                                        <property name="caption"></property>
-                                        <property name="caption_visible">1</property>
-                                        <property name="center_pane">0</property>
-                                        <property name="close_button">1</property>
-                                        <property name="context_help"></property>
-                                        <property name="context_menu">1</property>
-                                        <property name="default_pane">0</property>
-                                        <property name="dock">Dock</property>
-                                        <property name="dock_fixed">0</property>
-                                        <property name="docking">Left</property>
-                                        <property name="enabled">1</property>
-                                        <property name="fg"></property>
-                                        <property name="floatable">1</property>
-                                        <property name="font"></property>
-                                        <property name="gripper">0</property>
-                                        <property name="hidden">0</property>
-                                        <property name="id">wxID_ANY</property>
-                                        <property name="label">Name</property>
-                                        <property name="max_size"></property>
-                                        <property name="maximize_button">0</property>
-                                        <property name="maximum_size"></property>
-                                        <property name="min_size"></property>
-                                        <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
-                                        <property name="moveable">1</property>
-                                        <property name="name">m_stName</property>
+                                        <property name="name">m_panel2</property>
                                         <property name="pane_border">1</property>
                                         <property name="pane_position"></property>
                                         <property name="pane_size"></property>
@@ -529,14 +424,12 @@
                                         <property name="resize">Resizable</property>
                                         <property name="show">1</property>
                                         <property name="size"></property>
-                                        <property name="style"></property>
                                         <property name="subclass"></property>
                                         <property name="toolbar_pane">0</property>
                                         <property name="tooltip"></property>
                                         <property name="window_extra_style"></property>
                                         <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <property name="wrap">-1</property>
+                                        <property name="window_style">wxTAB_TRAVERSAL</property>
                                         <event name="OnChar"></event>
                                         <event name="OnEnterWindow"></event>
                                         <event name="OnEraseBackground"></event>
@@ -560,271 +453,367 @@
                                         <event name="OnSetFocus"></event>
                                         <event name="OnSize"></event>
                                         <event name="OnUpdateUI"></event>
-                                    </object>
-                                </object>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALL|wxEXPAND</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxTextCtrl" expanded="0">
-                                        <property name="BottomDockable">1</property>
-                                        <property name="LeftDockable">1</property>
-                                        <property name="RightDockable">1</property>
-                                        <property name="TopDockable">1</property>
-                                        <property name="aui_layer"></property>
-                                        <property name="aui_name"></property>
-                                        <property name="aui_position"></property>
-                                        <property name="aui_row"></property>
-                                        <property name="best_size"></property>
-                                        <property name="bg"></property>
-                                        <property name="caption"></property>
-                                        <property name="caption_visible">1</property>
-                                        <property name="center_pane">0</property>
-                                        <property name="close_button">1</property>
-                                        <property name="context_help"></property>
-                                        <property name="context_menu">1</property>
-                                        <property name="default_pane">0</property>
-                                        <property name="dock">Dock</property>
-                                        <property name="dock_fixed">0</property>
-                                        <property name="docking">Left</property>
-                                        <property name="enabled">0</property>
-                                        <property name="fg"></property>
-                                        <property name="floatable">1</property>
-                                        <property name="font"></property>
-                                        <property name="gripper">0</property>
-                                        <property name="hidden">0</property>
-                                        <property name="id">wxID_ANY</property>
-                                        <property name="max_size"></property>
-                                        <property name="maximize_button">0</property>
-                                        <property name="maximum_size"></property>
-                                        <property name="maxlength">0</property>
-                                        <property name="min_size"></property>
-                                        <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
-                                        <property name="moveable">1</property>
-                                        <property name="name">m_tSourceName</property>
-                                        <property name="pane_border">1</property>
-                                        <property name="pane_position"></property>
-                                        <property name="pane_size"></property>
-                                        <property name="permission">public</property>
-                                        <property name="pin_button">1</property>
-                                        <property name="pos"></property>
-                                        <property name="resize">Resizable</property>
-                                        <property name="show">1</property>
-                                        <property name="size"></property>
-                                        <property name="style"></property>
-                                        <property name="subclass"></property>
-                                        <property name="toolbar_pane">0</property>
-                                        <property name="tooltip"></property>
-                                        <property name="validator_data_type"></property>
-                                        <property name="validator_style">wxFILTER_NONE</property>
-                                        <property name="validator_type">wxDefaultValidator</property>
-                                        <property name="validator_variable"></property>
-                                        <property name="value"></property>
-                                        <property name="window_extra_style"></property>
-                                        <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <event name="OnChar"></event>
-                                        <event name="OnEnterWindow"></event>
-                                        <event name="OnEraseBackground"></event>
-                                        <event name="OnKeyDown"></event>
-                                        <event name="OnKeyUp"></event>
-                                        <event name="OnKillFocus"></event>
-                                        <event name="OnLeaveWindow"></event>
-                                        <event name="OnLeftDClick"></event>
-                                        <event name="OnLeftDown"></event>
-                                        <event name="OnLeftUp"></event>
-                                        <event name="OnMiddleDClick"></event>
-                                        <event name="OnMiddleDown"></event>
-                                        <event name="OnMiddleUp"></event>
-                                        <event name="OnMotion"></event>
-                                        <event name="OnMouseEvents"></event>
-                                        <event name="OnMouseWheel"></event>
-                                        <event name="OnPaint"></event>
-                                        <event name="OnRightDClick"></event>
-                                        <event name="OnRightDown"></event>
-                                        <event name="OnRightUp"></event>
-                                        <event name="OnSetFocus"></event>
-                                        <event name="OnSize"></event>
-                                        <event name="OnText"></event>
-                                        <event name="OnTextEnter"></event>
-                                        <event name="OnTextMaxLen"></event>
-                                        <event name="OnTextURL"></event>
-                                        <event name="OnUpdateUI"></event>
-                                    </object>
-                                </object>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxStaticText" expanded="0">
-                                        <property name="BottomDockable">1</property>
-                                        <property name="LeftDockable">1</property>
-                                        <property name="RightDockable">1</property>
-                                        <property name="TopDockable">1</property>
-                                        <property name="aui_layer"></property>
-                                        <property name="aui_name"></property>
-                                        <property name="aui_position"></property>
-                                        <property name="aui_row"></property>
-                                        <property name="best_size"></property>
-                                        <property name="bg"></property>
-                                        <property name="caption"></property>
-                                        <property name="caption_visible">1</property>
-                                        <property name="center_pane">0</property>
-                                        <property name="close_button">1</property>
-                                        <property name="context_help"></property>
-                                        <property name="context_menu">1</property>
-                                        <property name="default_pane">0</property>
-                                        <property name="dock">Dock</property>
-                                        <property name="dock_fixed">0</property>
-                                        <property name="docking">Left</property>
-                                        <property name="enabled">1</property>
-                                        <property name="fg"></property>
-                                        <property name="floatable">1</property>
-                                        <property name="font"></property>
-                                        <property name="gripper">0</property>
-                                        <property name="hidden">0</property>
-                                        <property name="id">wxID_ANY</property>
-                                        <property name="label">URL</property>
-                                        <property name="max_size"></property>
-                                        <property name="maximize_button">0</property>
-                                        <property name="maximum_size"></property>
-                                        <property name="min_size"></property>
-                                        <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
-                                        <property name="moveable">1</property>
-                                        <property name="name">m_stUrl</property>
-                                        <property name="pane_border">1</property>
-                                        <property name="pane_position"></property>
-                                        <property name="pane_size"></property>
-                                        <property name="permission">protected</property>
-                                        <property name="pin_button">1</property>
-                                        <property name="pos"></property>
-                                        <property name="resize">Resizable</property>
-                                        <property name="show">1</property>
-                                        <property name="size"></property>
-                                        <property name="style"></property>
-                                        <property name="subclass"></property>
-                                        <property name="toolbar_pane">0</property>
-                                        <property name="tooltip"></property>
-                                        <property name="window_extra_style"></property>
-                                        <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <property name="wrap">-1</property>
-                                        <event name="OnChar"></event>
-                                        <event name="OnEnterWindow"></event>
-                                        <event name="OnEraseBackground"></event>
-                                        <event name="OnKeyDown"></event>
-                                        <event name="OnKeyUp"></event>
-                                        <event name="OnKillFocus"></event>
-                                        <event name="OnLeaveWindow"></event>
-                                        <event name="OnLeftDClick"></event>
-                                        <event name="OnLeftDown"></event>
-                                        <event name="OnLeftUp"></event>
-                                        <event name="OnMiddleDClick"></event>
-                                        <event name="OnMiddleDown"></event>
-                                        <event name="OnMiddleUp"></event>
-                                        <event name="OnMotion"></event>
-                                        <event name="OnMouseEvents"></event>
-                                        <event name="OnMouseWheel"></event>
-                                        <event name="OnPaint"></event>
-                                        <event name="OnRightDClick"></event>
-                                        <event name="OnRightDown"></event>
-                                        <event name="OnRightUp"></event>
-                                        <event name="OnSetFocus"></event>
-                                        <event name="OnSize"></event>
-                                        <event name="OnUpdateUI"></event>
-                                    </object>
-                                </object>
-                                <object class="sizeritem" expanded="0">
-                                    <property name="border">5</property>
-                                    <property name="flag">wxALL|wxEXPAND</property>
-                                    <property name="proportion">0</property>
-                                    <object class="wxTextCtrl" expanded="0">
-                                        <property name="BottomDockable">1</property>
-                                        <property name="LeftDockable">1</property>
-                                        <property name="RightDockable">1</property>
-                                        <property name="TopDockable">1</property>
-                                        <property name="aui_layer"></property>
-                                        <property name="aui_name"></property>
-                                        <property name="aui_position"></property>
-                                        <property name="aui_row"></property>
-                                        <property name="best_size"></property>
-                                        <property name="bg"></property>
-                                        <property name="caption"></property>
-                                        <property name="caption_visible">1</property>
-                                        <property name="center_pane">0</property>
-                                        <property name="close_button">1</property>
-                                        <property name="context_help"></property>
-                                        <property name="context_menu">1</property>
-                                        <property name="default_pane">0</property>
-                                        <property name="dock">Dock</property>
-                                        <property name="dock_fixed">0</property>
-                                        <property name="docking">Left</property>
-                                        <property name="enabled">0</property>
-                                        <property name="fg"></property>
-                                        <property name="floatable">1</property>
-                                        <property name="font"></property>
-                                        <property name="gripper">0</property>
-                                        <property name="hidden">0</property>
-                                        <property name="id">wxID_ANY</property>
-                                        <property name="max_size"></property>
-                                        <property name="maximize_button">0</property>
-                                        <property name="maximum_size"></property>
-                                        <property name="maxlength">0</property>
-                                        <property name="min_size"></property>
-                                        <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
-                                        <property name="moveable">1</property>
-                                        <property name="name">m_tChartSourceUrl</property>
-                                        <property name="pane_border">1</property>
-                                        <property name="pane_position"></property>
-                                        <property name="pane_size"></property>
-                                        <property name="permission">public</property>
-                                        <property name="pin_button">1</property>
-                                        <property name="pos"></property>
-                                        <property name="resize">Resizable</property>
-                                        <property name="show">1</property>
-                                        <property name="size">-1,-1</property>
-                                        <property name="style"></property>
-                                        <property name="subclass"></property>
-                                        <property name="toolbar_pane">0</property>
-                                        <property name="tooltip"></property>
-                                        <property name="validator_data_type"></property>
-                                        <property name="validator_style">wxFILTER_NONE</property>
-                                        <property name="validator_type">wxDefaultValidator</property>
-                                        <property name="validator_variable"></property>
-                                        <property name="value"></property>
-                                        <property name="window_extra_style"></property>
-                                        <property name="window_name"></property>
-                                        <property name="window_style"></property>
-                                        <event name="OnChar"></event>
-                                        <event name="OnEnterWindow"></event>
-                                        <event name="OnEraseBackground"></event>
-                                        <event name="OnKeyDown"></event>
-                                        <event name="OnKeyUp"></event>
-                                        <event name="OnKillFocus"></event>
-                                        <event name="OnLeaveWindow"></event>
-                                        <event name="OnLeftDClick"></event>
-                                        <event name="OnLeftDown"></event>
-                                        <event name="OnLeftUp"></event>
-                                        <event name="OnMiddleDClick"></event>
-                                        <event name="OnMiddleDown"></event>
-                                        <event name="OnMiddleUp"></event>
-                                        <event name="OnMotion"></event>
-                                        <event name="OnMouseEvents"></event>
-                                        <event name="OnMouseWheel"></event>
-                                        <event name="OnPaint"></event>
-                                        <event name="OnRightDClick"></event>
-                                        <event name="OnRightDown"></event>
-                                        <event name="OnRightUp"></event>
-                                        <event name="OnSetFocus"></event>
-                                        <event name="OnSize"></event>
-                                        <event name="OnText"></event>
-                                        <event name="OnTextEnter"></event>
-                                        <event name="OnTextMaxLen"></event>
-                                        <event name="OnTextURL"></event>
-                                        <event name="OnUpdateUI"></event>
+                                        <object class="wxFlexGridSizer" expanded="1">
+                                            <property name="cols">2</property>
+                                            <property name="flexible_direction">wxBOTH</property>
+                                            <property name="growablecols">1</property>
+                                            <property name="growablerows"></property>
+                                            <property name="hgap">0</property>
+                                            <property name="minimum_size">-1,-1</property>
+                                            <property name="name">fgSizerSourceSel</property>
+                                            <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
+                                            <property name="permission">none</property>
+                                            <property name="rows">3</property>
+                                            <property name="vgap">0</property>
+                                            <object class="sizeritem" expanded="0">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxStaticText" expanded="0">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">Name</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">m_stName</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass"></property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <property name="wrap">-1</property>
+                                                    <event name="OnChar"></event>
+                                                    <event name="OnEnterWindow"></event>
+                                                    <event name="OnEraseBackground"></event>
+                                                    <event name="OnKeyDown"></event>
+                                                    <event name="OnKeyUp"></event>
+                                                    <event name="OnKillFocus"></event>
+                                                    <event name="OnLeaveWindow"></event>
+                                                    <event name="OnLeftDClick"></event>
+                                                    <event name="OnLeftDown"></event>
+                                                    <event name="OnLeftUp"></event>
+                                                    <event name="OnMiddleDClick"></event>
+                                                    <event name="OnMiddleDown"></event>
+                                                    <event name="OnMiddleUp"></event>
+                                                    <event name="OnMotion"></event>
+                                                    <event name="OnMouseEvents"></event>
+                                                    <event name="OnMouseWheel"></event>
+                                                    <event name="OnPaint"></event>
+                                                    <event name="OnRightDClick"></event>
+                                                    <event name="OnRightDown"></event>
+                                                    <event name="OnRightUp"></event>
+                                                    <event name="OnSetFocus"></event>
+                                                    <event name="OnSize"></event>
+                                                    <event name="OnUpdateUI"></event>
+                                                </object>
+                                            </object>
+                                            <object class="sizeritem" expanded="0">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALL|wxEXPAND</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxTextCtrl" expanded="0">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="maxlength">0</property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">m_tSourceName</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">public</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass"></property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip"></property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="value"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnChar"></event>
+                                                    <event name="OnEnterWindow"></event>
+                                                    <event name="OnEraseBackground"></event>
+                                                    <event name="OnKeyDown"></event>
+                                                    <event name="OnKeyUp"></event>
+                                                    <event name="OnKillFocus"></event>
+                                                    <event name="OnLeaveWindow"></event>
+                                                    <event name="OnLeftDClick"></event>
+                                                    <event name="OnLeftDown"></event>
+                                                    <event name="OnLeftUp"></event>
+                                                    <event name="OnMiddleDClick"></event>
+                                                    <event name="OnMiddleDown"></event>
+                                                    <event name="OnMiddleUp"></event>
+                                                    <event name="OnMotion"></event>
+                                                    <event name="OnMouseEvents"></event>
+                                                    <event name="OnMouseWheel"></event>
+                                                    <event name="OnPaint"></event>
+                                                    <event name="OnRightDClick"></event>
+                                                    <event name="OnRightDown"></event>
+                                                    <event name="OnRightUp"></event>
+                                                    <event name="OnSetFocus"></event>
+                                                    <event name="OnSize"></event>
+                                                    <event name="OnText"></event>
+                                                    <event name="OnTextEnter"></event>
+                                                    <event name="OnTextMaxLen"></event>
+                                                    <event name="OnTextURL"></event>
+                                                    <event name="OnUpdateUI"></event>
+                                                </object>
+                                            </object>
+                                            <object class="sizeritem" expanded="0">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxStaticText" expanded="0">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">URL</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">m_stUrl</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass"></property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <property name="wrap">-1</property>
+                                                    <event name="OnChar"></event>
+                                                    <event name="OnEnterWindow"></event>
+                                                    <event name="OnEraseBackground"></event>
+                                                    <event name="OnKeyDown"></event>
+                                                    <event name="OnKeyUp"></event>
+                                                    <event name="OnKillFocus"></event>
+                                                    <event name="OnLeaveWindow"></event>
+                                                    <event name="OnLeftDClick"></event>
+                                                    <event name="OnLeftDown"></event>
+                                                    <event name="OnLeftUp"></event>
+                                                    <event name="OnMiddleDClick"></event>
+                                                    <event name="OnMiddleDown"></event>
+                                                    <event name="OnMiddleUp"></event>
+                                                    <event name="OnMotion"></event>
+                                                    <event name="OnMouseEvents"></event>
+                                                    <event name="OnMouseWheel"></event>
+                                                    <event name="OnPaint"></event>
+                                                    <event name="OnRightDClick"></event>
+                                                    <event name="OnRightDown"></event>
+                                                    <event name="OnRightUp"></event>
+                                                    <event name="OnSetFocus"></event>
+                                                    <event name="OnSize"></event>
+                                                    <event name="OnUpdateUI"></event>
+                                                </object>
+                                            </object>
+                                            <object class="sizeritem" expanded="0">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALL|wxEXPAND</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxTextCtrl" expanded="0">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="maxlength">0</property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">m_tChartSourceUrl</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">public</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size">-1,-1</property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass"></property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip"></property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="value"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnChar"></event>
+                                                    <event name="OnEnterWindow"></event>
+                                                    <event name="OnEraseBackground"></event>
+                                                    <event name="OnKeyDown"></event>
+                                                    <event name="OnKeyUp"></event>
+                                                    <event name="OnKillFocus"></event>
+                                                    <event name="OnLeaveWindow"></event>
+                                                    <event name="OnLeftDClick"></event>
+                                                    <event name="OnLeftDown"></event>
+                                                    <event name="OnLeftUp"></event>
+                                                    <event name="OnMiddleDClick"></event>
+                                                    <event name="OnMiddleDown"></event>
+                                                    <event name="OnMiddleUp"></event>
+                                                    <event name="OnMotion"></event>
+                                                    <event name="OnMouseEvents"></event>
+                                                    <event name="OnMouseWheel"></event>
+                                                    <event name="OnPaint"></event>
+                                                    <event name="OnRightDClick"></event>
+                                                    <event name="OnRightDown"></event>
+                                                    <event name="OnRightUp"></event>
+                                                    <event name="OnSetFocus"></event>
+                                                    <event name="OnSize"></event>
+                                                    <event name="OnText"></event>
+                                                    <event name="OnTextEnter"></event>
+                                                    <event name="OnTextMaxLen"></event>
+                                                    <event name="OnTextURL"></event>
+                                                    <event name="OnUpdateUI"></event>
+                                                </object>
+                                            </object>
+                                        </object>
                                     </object>
                                 </object>
                             </object>
@@ -961,7 +950,7 @@
                 </object>
             </object>
         </object>
-        <object class="Panel" expanded="1">
+        <object class="Panel" expanded="0">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -1013,16 +1002,16 @@
             <event name="OnSetFocus"></event>
             <event name="OnSize"></event>
             <event name="OnUpdateUI"></event>
-            <object class="wxBoxSizer" expanded="1">
+            <object class="wxBoxSizer" expanded="0">
                 <property name="minimum_size">-1,-1</property>
                 <property name="name">bSizer1</property>
                 <property name="orient">wxVERTICAL</property>
                 <property name="permission">none</property>
-                <object class="sizeritem" expanded="1">
+                <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxALL|wxEXPAND</property>
                     <property name="proportion">0</property>
-                    <object class="wxStaticBoxSizer" expanded="1">
+                    <object class="wxStaticBoxSizer" expanded="0">
                         <property name="id">wxID_ANY</property>
                         <property name="label">Catalogs</property>
                         <property name="minimum_size"></property>
@@ -1030,11 +1019,11 @@
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
-                        <object class="sizeritem" expanded="1">
+                        <object class="sizeritem" expanded="0">
                             <property name="border">0</property>
                             <property name="flag">wxEXPAND</property>
                             <property name="proportion">1</property>
-                            <object class="wxBoxSizer" expanded="1">
+                            <object class="wxBoxSizer" expanded="0">
                                 <property name="minimum_size"></property>
                                 <property name="name">bSizer4</property>
                                 <property name="orient">wxHORIZONTAL</property>
@@ -1144,11 +1133,11 @@
                                         <event name="OnUpdateUI"></event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxBoxSizer" expanded="1">
+                                    <object class="wxBoxSizer" expanded="0">
                                         <property name="minimum_size"></property>
                                         <property name="name">bSizer8</property>
                                         <property name="orient">wxVERTICAL</property>
@@ -1511,7 +1500,7 @@
                         </object>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="1">
+                <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxALL|wxEXPAND</property>
                     <property name="proportion">1</property>
@@ -1799,7 +1788,7 @@
                 </object>
             </object>
         </object>
-        <object class="Dialog" expanded="1">
+        <object class="Dialog" expanded="0">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -1861,7 +1850,7 @@
             <event name="OnSetFocus"></event>
             <event name="OnSize"></event>
             <event name="OnUpdateUI"></event>
-            <object class="wxBoxSizer" expanded="1">
+            <object class="wxBoxSizer" expanded="0">
                 <property name="minimum_size"></property>
                 <property name="name">bSizerPrefsMain</property>
                 <property name="orient">wxVERTICAL</property>
@@ -1968,11 +1957,11 @@
                         </object>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="1">
+                <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxALL|wxEXPAND</property>
                     <property name="proportion">1</property>
-                    <object class="wxStaticBoxSizer" expanded="1">
+                    <object class="wxStaticBoxSizer" expanded="0">
                         <property name="id">wxID_ANY</property>
                         <property name="label">Preferences</property>
                         <property name="minimum_size"></property>
@@ -1980,11 +1969,11 @@
                         <property name="orient">wxVERTICAL</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
-                        <object class="sizeritem" expanded="1">
+                        <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
                             <property name="flag">wxALL</property>
                             <property name="proportion">0</property>
-                            <object class="wxStaticText" expanded="1">
+                            <object class="wxStaticText" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -2063,11 +2052,11 @@
                                 <event name="OnUpdateUI"></event>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="1">
+                        <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
                             <property name="flag">wxALL</property>
                             <property name="proportion">0</property>
-                            <object class="wxCheckBox" expanded="1">
+                            <object class="wxCheckBox" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -2151,11 +2140,11 @@
                                 <event name="OnUpdateUI"></event>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="1">
+                        <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
                             <property name="flag">wxALL</property>
                             <property name="proportion">0</property>
-                            <object class="wxCheckBox" expanded="1">
+                            <object class="wxCheckBox" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>

--- a/data/chart_sources.xml
+++ b/data/chart_sources.xml
@@ -1,0 +1,864 @@
+<?xml version="1.0"?>
+<ChartCatalog>
+  <sections>
+    <section>
+      <name>NOAA</name>
+      <sections>
+        <section>
+          <name>RNC</name>
+          <sections>
+            <section>
+              <name>All RNCs</name>
+              <catalogs>
+                <catalog>
+                  <name>All</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC</dir>
+                </catalog>
+              </catalogs>
+            </section>
+            <section>
+              <name>by Coast Guard Districts</name>
+              <catalogs>
+                <catalog>
+                  <name>01 CGD - New England states, eastern New York, and northern New Jersey</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/01CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD01</dir>
+                </catalog>
+                <catalog>
+                  <name>05 CGD - Pennsylvania, southern New Jersey, Delaware, Maryland, Virginia, and North Carolina</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/05CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD05</dir>
+                </catalog>
+                <catalog>
+                  <name>07 CGD - South Carolina, Georgia, eastern Florida, Puerto Rico, and the U.S. Virgin Islands</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/07CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD07</dir>
+                </catalog>
+                <catalog>
+                  <name>08 CGD - Inland waters of the U.S. and the Gulf of Mexico</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/08CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD08</dir>
+                </catalog>
+                <catalog>
+                  <name>09 CGD - Great Lakes</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/09CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD09</dir>
+                </catalog>
+                <catalog>
+                  <name>11 CGD - California, Arizona, Nevada, and Utah</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/11CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD11</dir>
+                </catalog>
+                <catalog>
+                  <name>13 CGD - Oregon, Washington, Idaho and Montana</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/13CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD13</dir>
+                </catalog>
+                <catalog>
+                  <name>14 CGD - Hawaii and Pacific territories</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/14CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD14</dir>
+                </catalog>
+                <catalog>
+                  <name>17 CGD - Alaska</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/17CGD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CGD17</dir>
+                </catalog>
+              </catalogs>
+            </section>
+            <section>
+              <name>by States</name>
+              <catalogs>
+                <catalog>
+                  <name>AK - Alaska</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/AK_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_AK</dir>
+                </catalog>
+                <catalog>
+                  <name>AL - Alabama</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/AL_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_AL</dir>
+                </catalog>
+                <catalog>
+                  <name>CA - California</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/CA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CA</dir>
+                </catalog>
+                <catalog>
+                  <name>CT - Connecticut</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/CT_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_CT</dir>
+                </catalog>
+                <catalog>
+                  <name>DE - Delaware</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/DE_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_DE</dir>
+                </catalog>
+                <catalog>
+                  <name>FL - Florida</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/FL_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_FL</dir>
+                </catalog>
+                <catalog>
+                  <name>GA - Georgia</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/GA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_GA</dir>
+                </catalog>
+                <catalog>
+                  <name>HI - Hawaii</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/HI_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_HI</dir>
+                </catalog>
+                <catalog>
+                  <name>ID - Idaho</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/ID_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_ID</dir>
+                </catalog>
+                <catalog>
+                  <name>IL - Illinois</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/IL_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_IL</dir>
+                </catalog>
+                <catalog>
+                  <name>IN - Indiana</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/IN_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_IN</dir>
+                </catalog>
+                <catalog>
+                  <name>LA - Louisiana</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/LA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_LA</dir>
+                </catalog>
+                <catalog>
+                  <name>MA - Massachusetts</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/MA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_MA</dir>
+                </catalog>
+                <catalog>
+                  <name>MD - Maryland</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/MD_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_MD</dir>
+                </catalog>
+                <catalog>
+                  <name>ME - Maine</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/ME_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_ME</dir>
+                </catalog>
+                <catalog>
+                  <name>MI - Michigan</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/MI_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_MI</dir>
+                </catalog>
+                <catalog>
+                  <name>MN - Minnesota</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/MN_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_MN</dir>
+                </catalog>
+                <catalog>
+                  <name>MS - Mississippi</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/MS_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_MS</dir>
+                </catalog>
+                <catalog>
+                  <name>NC - North Carolina</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/NC_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_NC</dir>
+                </catalog>
+                <catalog>
+                  <name>NH - New Hampshire</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/NH_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_NH</dir>
+                </catalog>
+                <catalog>
+                  <name>NJ - New Jersey</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/NJ_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_NJ</dir>
+                </catalog>
+                <catalog>
+                  <name>NV - Nevada</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/NV_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_NV</dir>
+                </catalog>
+                <catalog>
+                  <name>NY - New York</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/NY_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_NY</dir>
+                </catalog>
+                <catalog>
+                  <name>OH - Ohio</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/OH_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_OH</dir>
+                </catalog>
+                <catalog>
+                  <name>OR - Oregon</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/OR_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_OR</dir>
+                </catalog>
+                <catalog>
+                  <name>PA - Pennsylvania</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/PA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_PA</dir>
+                </catalog>
+                <catalog>
+                  <name>PO - Pacific Ocean</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/PO_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_PO</dir>
+                </catalog>
+                <catalog>
+                  <name>PR - Puerto Rico and Virgin Islands</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/PR_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_PR</dir>
+                </catalog>
+                <catalog>
+                  <name>RI - Rhode Island</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/RI_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_RI</dir>
+                </catalog>
+                <catalog>
+                  <name>SC - South Carolina</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/SC_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_SC</dir>
+                </catalog>
+                <catalog>
+                  <name>TX - Texas</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/TX_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_TX</dir>
+                </catalog>
+                <catalog>
+                  <name>VA - Virginia</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/VA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_VA</dir>
+                </catalog>
+                <catalog>
+                  <name>VT - Vermont</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/VT_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_VT</dir>
+                </catalog>
+                <catalog>
+                  <name>WA - Washington</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/WA_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_WA</dir>
+                </catalog>
+                <catalog>
+                  <name>WI - Wisconsin</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/WI_RNCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/RNC/US_WI</dir>
+                </catalog>
+              </catalogs>
+            </section>
+            <section>
+              <name>by Region</name>
+              <catalogs>
+                <catalog>
+                  <name>Region 02 - Block Island, RI to the Canadian Border</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/02Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION02</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 03 - New York to Nantucket and Cape May, NJ</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/03Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION03</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 04 - Chesapeake and Delaware Bays</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/04Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION04</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 06 - Norfolk, VA to Florida including the ICW</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/06Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION06</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 07 - Florida East Coast and the Keys</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/07Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION07</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 08 - Florida West Coast and the Keys</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/08Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION08</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 10 - Puerto Rico and the U.S. Virgin Islands</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/10Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION10</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 12 - Southern California: Point Arena to the Mexican Border</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/12Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION12</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 13 - Lake Michigan</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/13Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION13</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 14 - San Francisco to Cape Flattery</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/14Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION14</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 15 - Pacific Northwest: Puget Sound to the Canadian Border</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/15Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION15</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 17 - Mobile, AL to the Mexican Border</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/17Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION17</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 22 - Lake Superior and Lake Huron (U.S. Waters)</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/22Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION22</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 24 - Lake Erie (U.S. Waters)</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/24Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION24</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 26 - Lake Ontario (U.S. Waters)</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/26Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION26</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 30 - Southeast Alaska</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/30Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION30</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 32 - South Central Alaska: Yakutat to Kodiak</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/32Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION32</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 34 - Alaska: The Aleutians and Bristol Bay</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/34Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION34</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 36 - Alaska: Norton Sound to Beaufort Sea</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/36Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION36</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 40 - Hawaiian Islands and U.S. Territories</name>
+                  <type>RNC</type>
+                  <location>http://www.charts.noaa.gov/RNCs/40Region_RNCProdCat.xml</location>
+                  <dir>{USERDATA}/RNC/US_REGION40</dir>
+                </catalog>
+              </catalogs>
+            </section>
+          </sections>
+        </section>
+        <section>
+          <name>ENC</name>
+          <sections>
+            <section>
+              <name>All ENCs</name>
+              <catalogs>
+                <catalog>
+                  <name>All</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC</dir>
+                </catalog>
+              </catalogs>
+            </section>
+            <section>
+              <name>by Coast Guard Districts</name>
+              <catalogs>
+                <catalog>
+                  <name>01 CGD - New England states, eastern New York, and northern New Jersey</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/01CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD01</dir>
+                </catalog>
+                <catalog>
+                  <name>05 CGD - Pennsylvania, southern New Jersey, Delaware, Maryland, Virginia, and North Carolina</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/05CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD05</dir>
+                </catalog>
+                <catalog>
+                  <name>07 CGD - South Carolina, Georgia, eastern Florida, Puerto Rico, and the U.S. Virgin Islands</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/07CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD07</dir>
+                </catalog>
+                <catalog>
+                  <name>08 CGD - Inland waters of the U.S. and the Gulf of Mexico</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/08CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD08</dir>
+                </catalog>
+                <catalog>
+                  <name>09 CGD - Great Lakes</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/09CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD09</dir>
+                </catalog>
+                <catalog>
+                  <name>11 CGD - California, Arizona, Nevada, and Utah</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/11CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD11</dir>
+                </catalog>
+                <catalog>
+                  <name>13 CGD - Oregon, Washington, Idaho and Montana</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/13CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD13</dir>
+                </catalog>
+                <catalog>
+                  <name>14 CGD - Hawaii and Pacific territories</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/14CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD14</dir>
+                </catalog>
+                <catalog>
+                  <name>17 CGD - Alaska</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/17CGD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CGD17</dir>
+                </catalog>
+              </catalogs>
+            </section>
+            <section>
+              <name>by States</name>
+              <catalogs>
+                <catalog>
+                  <name>AK - Alaska</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/AK_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_AK</dir>
+                </catalog>
+                <catalog>
+                  <name>AL - Alabama</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/AL_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_AL</dir>
+                </catalog>
+                <catalog>
+                  <name>CA - California</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/CA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CA</dir>
+                </catalog>
+                <catalog>
+                  <name>CT - Connecticut</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/CT_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_CT</dir>
+                </catalog>
+                <catalog>
+                  <name>DE - Delaware</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/DE_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_DE</dir>
+                </catalog>
+                <catalog>
+                  <name>FL - Florida</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/FL_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_FL</dir>
+                </catalog>
+                <catalog>
+                  <name>GA - Georgia</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/GA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_GA</dir>
+                </catalog>
+                <catalog>
+                  <name>HI - Hawaii</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/HI_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_HI</dir>
+                </catalog>
+                <catalog>
+                  <name>ID - Idaho</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/ID_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_ID</dir>
+                </catalog>
+                <catalog>
+                  <name>IL - Illinois</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/IL_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_IL</dir>
+                </catalog>
+                <catalog>
+                  <name>IN - Indiana</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/IN_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_IN</dir>
+                </catalog>
+                <catalog>
+                  <name>LA - Louisiana</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/LA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_LA</dir>
+                </catalog>
+                <catalog>
+                  <name>MA - Massachusetts</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/MA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_MA</dir>
+                </catalog>
+                <catalog>
+                  <name>MD - Maryland</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/MD_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_MD</dir>
+                </catalog>
+                <catalog>
+                  <name>ME - Maine</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/ME_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_ME</dir>
+                </catalog>
+                <catalog>
+                  <name>MI - Michigan</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/MI_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_MI</dir>
+                </catalog>
+                <catalog>
+                  <name>MN - Minnesota</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/MN_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_MN</dir>
+                </catalog>
+                <catalog>
+                  <name>MS - Mississippi</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/MS_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_MS</dir>
+                </catalog>
+                <catalog>
+                  <name>NC - North Carolina</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/NC_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_NC</dir>
+                </catalog>
+                <catalog>
+                  <name>NH - New Hampshire</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/NH_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_NH</dir>
+                </catalog>
+                <catalog>
+                  <name>NJ - New Jersey</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/NJ_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_NJ</dir>
+                </catalog>
+                <catalog>
+                  <name>NV - Nevada</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/NV_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_NV</dir>
+                </catalog>
+                <catalog>
+                  <name>NY - New York</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/NY_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_NY</dir>
+                </catalog>
+                <catalog>
+                  <name>OH - Ohio</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/OH_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_OH</dir>
+                </catalog>
+                <catalog>
+                  <name>OR - Oregon</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/OR_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_OR</dir>
+                </catalog>
+                <catalog>
+                  <name>PA - Pennsylvania</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/PA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_PA</dir>
+                </catalog>
+                <catalog>
+                  <name>PO - Pacific Ocean</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/PO_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_PO</dir>
+                </catalog>
+                <catalog>
+                  <name>PR - Puerto Rico and Virgin Islands</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/PR_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_PR</dir>
+                </catalog>
+                <catalog>
+                  <name>RI - Rhode Island</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/RI_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_RI</dir>
+                </catalog>
+                <catalog>
+                  <name>SC - South Carolina</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/SC_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_SC</dir>
+                </catalog>
+                <catalog>
+                  <name>TX - Texas</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/TX_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_TX</dir>
+                </catalog>
+                <catalog>
+                  <name>VA - Virginia</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/VA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_VA</dir>
+                </catalog>
+                <catalog>
+                  <name>VT - Vermont</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/VT_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_VT</dir>
+                </catalog>
+                <catalog>
+                  <name>WA - Washington</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/WA_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_WA</dir>
+                </catalog>
+                <catalog>
+                  <name>WI - Wisconsin</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/WI_ENCProdCat_19115.xml</location>
+                  <dir>{USERDATA}/ENC/US_WI</dir>
+                </catalog>
+              </catalogs>
+            </section>
+            <section>
+              <name>by Region</name>
+              <catalogs>
+                <catalog>
+                  <name>Region 02 - Block Island, RI to the Canadian Border</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/02Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION02</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 03 - New York to Nantucket and Cape May, NJ</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/03Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION03</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 04 - Chesapeake and Delaware Bays</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/04Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION04</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 06 - Norfolk, VA to Florida including the ICW</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/06Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION06</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 07 - Florida East Coast and the Keys</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/07Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION07</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 08 - Florida West Coast and the Keys</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/08Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION08</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 10 - Puerto Rico and the U.S. Virgin Islands</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/10Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION10</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 12 - Southern California: Point Arena to the Mexican Border</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/12Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION12</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 13 - Lake Michigan</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/13Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION13</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 14 - San Francisco to Cape Flattery</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/14Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION14</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 15 - Pacific Northwest: Puget Sound to the Canadian Border</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/15Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION15</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 17 - Mobile, AL to the Mexican Border</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/17Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION17</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 22 - Lake Superior and Lake Huron (U.S. Waters)</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/22Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION22</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 24 - Lake Erie (U.S. Waters)</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/24Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION24</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 26 - Lake Ontario (U.S. Waters)</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/26Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION26</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 30 - Southeast Alaska</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/30Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION30</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 32 - South Central Alaska: Yakutat to Kodiak</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/32Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION32</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 34 - Alaska: The Aleutians and Bristol Bay</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/34Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION34</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 36 - Alaska: Norton Sound to Beaufort Sea</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/36Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION36</dir>
+                </catalog>
+                <catalog>
+                  <name>Region 40 - Hawaiian Islands and U.S. Territories</name>
+                  <type>ENC</type>
+                  <location>http://www.charts.noaa.gov/ENCs/40Region_ENCProdCat.xml</location>
+                  <dir>{USERDATA}/ENC/US_REGION40</dir>
+                </catalog>
+              </catalogs>
+            </section>
+          </sections>
+          <catalogs>
+            <catalog>
+              <name>US ACE Inland ENC charts</name>
+              <location>http://inland.agc.army.mil/enc/echarts/catalog/iencu37productscatalog.xml</location>
+              <dir>{USERDATA}/ENC/US_INLAND</dir>
+            </catalog>
+          </catalogs>
+        </section>
+      </sections>
+    </section>
+    <section>
+      <name>ChartCatalogs</name>
+      <catalogs>
+        <catalog>
+          <name>Brasil RNC Nautical Charts</name>
+          <type>RNC</type>
+          <location>https://raw.githubusercontent.com/chartcatalogs/catalogs/master/BR_RNC_Catalog.xml</location>
+          <dir>{USERDATA}/RNC/BRASIL</dir>
+        </catalog>
+        <catalog>
+          <name>Czech Republic Inland ENC Charts</name>
+          <type>ENC</type>
+          <location>https://raw.githubusercontent.com/chartcatalogs/catalogs/master/CZ_IENC_Catalog.xml</location>
+          <dir>{USERDATA}/ENC/CZ_INLAND</dir>
+        </catalog>
+      </catalogs>
+    </section>
+  </sections>
+</ChartCatalog>

--- a/src/chartdldr_pi.h
+++ b/src/chartdldr_pi.h
@@ -45,50 +45,6 @@
 #define     MY_API_VERSION_MAJOR    1
 #define     MY_API_VERSION_MINOR    12
 
-#define     NOAA_CHART_SOURCES "US RNC Region 02 - Block Island, RI to the Canadian Border|http://www.charts.noaa.gov/RNCs/02Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION02|\
-US RNC Region 03 - New York to Nantucket and Cape May, NJ|http://www.charts.noaa.gov/RNCs/03Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION03|\
-US RNC Region 04 - Chesapeake and Delaware Bays|http://www.charts.noaa.gov/RNCs/04Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION04|\
-US RNC Region 06 - Norfolk, VA to Florida including the ICW|http://www.charts.noaa.gov/RNCs/06Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION06|\
-US RNC Region 07 - Florida East Coast and the Keys|http://www.charts.noaa.gov/RNCs/07Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION07|\
-US RNC Region 08 - Florida West Coast and the Keys|http://www.charts.noaa.gov/RNCs/08Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION08|\
-US RNC Region 10 - Puerto Rico and the U.S. Virgin Islands|http://www.charts.noaa.gov/RNCs/10Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION10|\
-US RNC Region 12 - Southern California: Point Arena to the Mexican Border|http://www.charts.noaa.gov/RNCs/12Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION12|\
-US RNC Region 13 - Lake Michigan|http://www.charts.noaa.gov/RNCs/13Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION13|\
-US RNC Region 14 - San Francisco to Cape Flattery|http://www.charts.noaa.gov/RNCs/14Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION14|\
-US RNC Region 15 - Pacific Northwest: Puget Sound to the Canadian Border|http://www.charts.noaa.gov/RNCs/15Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION15|\
-US RNC Region 17 - Mobile, AL to the Mexican Border|http://www.charts.noaa.gov/RNCs/17Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION17|\
-US RNC Region 22 - Lake Superior and Lake Huron (U.S. Waters)|http://www.charts.noaa.gov/RNCs/22Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION22|\
-US RNC Region 24 - Lake Erie (U.S. Waters)|http://www.charts.noaa.gov/RNCs/24Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION24|\
-US RNC Region 26 - Lake Ontario (U.S. Waters)|http://www.charts.noaa.gov/RNCs/26Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION26|\
-US RNC Region 30 - Southeast Alaska|http://www.charts.noaa.gov/RNCs/30Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION30|\
-US RNC Region 32 - South Central Alaska: Yakutat to Kodiak|http://www.charts.noaa.gov/RNCs/32Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION32|\
-US RNC Region 34 - Alaska: The Aleutians and Bristol Bay|http://www.charts.noaa.gov/RNCs/34Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION34|\
-US RNC Region 36 - Alaska: Norton Sound to Beaufort Sea|http://www.charts.noaa.gov/RNCs/36Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION36|\
-US RNC Region 40 - Hawaiian Islands and U.S. Territories|http://www.charts.noaa.gov/RNCs/40Region_RNCProdCat.xml|{USERDATA}/RNC/US_REGION40|\
-US ENC Region 02 - Block Island, RI to the Canadian Border|http://www.charts.noaa.gov/ENCs/02Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION02|\
-US ENC Region 03 - New York to Nantucket and Cape May, NJ|http://www.charts.noaa.gov/ENCs/03Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION03|\
-US ENC Region 04 - Chesapeake and Delaware Bays|http://www.charts.noaa.gov/ENCs/04Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION04|\
-US ENC Region 06 - Norfolk, VA to Florida including the ICW|http://www.charts.noaa.gov/ENCs/06Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION06|\
-US ENC Region 07 - Florida East Coast and the Keys|http://www.charts.noaa.gov/ENCs/07Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION07|\
-US ENC Region 08 - Florida West Coast and the Keys|http://www.charts.noaa.gov/ENCs/08Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION08|\
-US ENC Region 10 - Puerto Rico and the U.S. Virgin Islands|http://www.charts.noaa.gov/ENCs/10Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION10|\
-US ENC Region 12 - Southern California: Point Arena to the Mexican Border|http://www.charts.noaa.gov/ENCs/12Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION12|\
-US ENC Region 13 - Lake Michigan|http://www.charts.noaa.gov/ENCs/13Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION13|\
-US ENC Region 14 - San Francisco to Cape Flattery|http://www.charts.noaa.gov/ENCs/14Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION14|\
-US ENC Region 15 - Pacific Northwest: Puget Sound to the Canadian Border|http://www.charts.noaa.gov/ENCs/15Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION15|\
-US ENC Region 17 - Mobile, AL to the Mexican Border|http://www.charts.noaa.gov/ENCs/17Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION17|\
-US ENC Region 22 - Lake Superior and Lake Huron (U.S. Waters)|http://www.charts.noaa.gov/ENCs/22Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION22|\
-US ENC Region 24 - Lake Erie (U.S. Waters)|http://www.charts.noaa.gov/ENCs/24Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION24|\
-US ENC Region 26 - Lake Ontario (U.S. Waters)|http://www.charts.noaa.gov/ENCs/26Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION26|\
-US ENC Region 30 - Southeast Alaska|http://www.charts.noaa.gov/ENCs/30Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION30|\
-US ENC Region 32 - South Central Alaska: Yakutat to Kodiak|http://www.charts.noaa.gov/ENCs/32Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION32|\
-US ENC Region 34 - Alaska: The Aleutians and Bristol Bay|http://www.charts.noaa.gov/ENCs/34Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION34|\
-US ENC Region 36 - Alaska: Norton Sound to Beaufort Sea|http://www.charts.noaa.gov/ENCs/36Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION36|\
-US ENC Region 40 - Hawaiian Islands and U.S. Territories|http://www.charts.noaa.gov/ENCs/40Region_ENCProdCat.xml|{USERDATA}/ENC/US_REGION40|\
-US ACE Inland ENC charts|http://inland.agc.army.mil/enc/echarts/catalog/iencu37productscatalog.xml|{USERDATA}/ENC/US_INLAND|\
-Brasil RNC Nautical Charts|https://raw.githubusercontent.com/chartcatalogs/catalogs/master/BR_RNC_Catalog.xml|{USERDATA}/RNC/BRASIL|\
-Czech Republic Inland ENC Charts|https://raw.githubusercontent.com/chartcatalogs/catalogs/master/CZ_IENC_Catalog.xml|{USERDATA}/ENC/CZ_INLAND|"
-
 #define USERDATA "{USERDATA}"
 
 #include "ocpn_plugin.h"
@@ -161,7 +117,7 @@ private:
       wxString          m_base_chart_dir;
 };
 
-class ChartSource
+class ChartSource : public wxTreeItemData
 {
 public:
       ChartSource(wxString name, wxString url, wxString localdir);
@@ -228,10 +184,14 @@ public:
 class ChartDldrGuiAddSourceDlg : public AddSourceDlg
 {
 	protected:
-        wxArrayOfChartSources *m_chartSources;
 		void OnChangeType( wxCommandEvent& event );
-		void OnSourceSelected( wxCommandEvent& event );
+		void OnSourceSelected( wxTreeEvent& event );
 		void OnOkClick( wxCommandEvent& event );
+        bool LoadSources();
+        bool LoadSections(const wxTreeItemId &root, TiXmlNode *node);
+        bool LoadSection(const wxTreeItemId &root, TiXmlNode *node);
+        bool LoadCatalogs(const wxTreeItemId &root, TiXmlNode *node);
+        bool LoadCatalog(const wxTreeItemId &root, TiXmlNode *node);
 
 	public:
 		ChartDldrGuiAddSourceDlg( wxWindow* parent );

--- a/src/chartdldrgui.cpp
+++ b/src/chartdldrgui.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Jun  6 2014)
+// C++ code generated with wxFormBuilder (version Jun  5 2014)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -19,55 +19,51 @@ AddSourceDlg::AddSourceDlg( wxWindow* parent, wxWindowID id, const wxString& tit
 	wxStaticBoxSizer* sbSizerSourceSel;
 	sbSizerSourceSel = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Catalog") ), wxVERTICAL );
 	
-	wxBoxSizer* bSizerType;
-	bSizerType = new wxBoxSizer( wxHORIZONTAL );
+	m_nbChoice = new wxNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP );
+	m_nbChoice->SetMinSize( wxSize( -1,200 ) );
 	
-	m_rbPredefined = new wxRadioButton( this, wxID_ANY, _("Predefined"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizerType->Add( m_rbPredefined, 0, wxALL|wxEXPAND, 5 );
+	m_panel1 = new wxPanel( m_nbChoice, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	wxBoxSizer* bSizer8;
+	bSizer8 = new wxBoxSizer( wxVERTICAL );
 	
-	m_rbCustom = new wxRadioButton( this, wxID_ANY, _("Custom"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizerType->Add( m_rbCustom, 0, wxALL, 5 );
+	m_treeCtrl1 = new wxTreeCtrl( m_panel1, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE|wxTR_HIDE_ROOT );
+	bSizer8->Add( m_treeCtrl1, 1, wxALL|wxEXPAND, 5 );
 	
 	
-	sbSizerSourceSel->Add( bSizerType, 0, wxEXPAND, 5 );
-	
+	m_panel1->SetSizer( bSizer8 );
+	m_panel1->Layout();
+	bSizer8->Fit( m_panel1 );
+	m_nbChoice->AddPage( m_panel1, _("Predefined"), true );
+	m_panel2 = new wxPanel( m_nbChoice, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 	wxFlexGridSizer* fgSizerSourceSel;
 	fgSizerSourceSel = new wxFlexGridSizer( 3, 2, 0, 0 );
 	fgSizerSourceSel->AddGrowableCol( 1 );
 	fgSizerSourceSel->SetFlexibleDirection( wxBOTH );
 	fgSizerSourceSel->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 	
-	m_stCatalog = new wxStaticText( this, wxID_ANY, _("Catalog"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stCatalog->Wrap( -1 );
-	fgSizerSourceSel->Add( m_stCatalog, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	wxArrayString m_cbChartSourcesChoices;
-	m_cbChartSources = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_cbChartSourcesChoices, 0 );
-	m_cbChartSources->SetSelection( 0 );
-	fgSizerSourceSel->Add( m_cbChartSources, 0, wxALL|wxEXPAND, 5 );
-	
-	m_stName = new wxStaticText( this, wxID_ANY, _("Name"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_stName = new wxStaticText( m_panel2, wxID_ANY, _("Name"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_stName->Wrap( -1 );
 	fgSizerSourceSel->Add( m_stName, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	
-	m_tSourceName = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+	m_tSourceName = new wxTextCtrl( m_panel2, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 	m_tSourceName->SetMaxLength( 0 ); 
-	m_tSourceName->Enable( false );
-	
 	fgSizerSourceSel->Add( m_tSourceName, 0, wxALL|wxEXPAND, 5 );
 	
-	m_stUrl = new wxStaticText( this, wxID_ANY, _("URL"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_stUrl = new wxStaticText( m_panel2, wxID_ANY, _("URL"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_stUrl->Wrap( -1 );
 	fgSizerSourceSel->Add( m_stUrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	
-	m_tChartSourceUrl = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1,-1 ), 0 );
+	m_tChartSourceUrl = new wxTextCtrl( m_panel2, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1,-1 ), 0 );
 	m_tChartSourceUrl->SetMaxLength( 0 ); 
-	m_tChartSourceUrl->Enable( false );
-	
 	fgSizerSourceSel->Add( m_tChartSourceUrl, 0, wxALL|wxEXPAND, 5 );
 	
 	
-	sbSizerSourceSel->Add( fgSizerSourceSel, 1, wxALL|wxEXPAND, 5 );
+	m_panel2->SetSizer( fgSizerSourceSel );
+	m_panel2->Layout();
+	fgSizerSourceSel->Fit( m_panel2 );
+	m_nbChoice->AddPage( m_panel2, _("Custom"), false );
+	
+	sbSizerSourceSel->Add( m_nbChoice, 1, wxEXPAND | wxALL, 5 );
 	
 	
 	bSizerMain->Add( sbSizerSourceSel, 1, wxALL|wxEXPAND, 5 );
@@ -98,18 +94,14 @@ AddSourceDlg::AddSourceDlg( wxWindow* parent, wxWindowID id, const wxString& tit
 	this->Centre( wxBOTH );
 	
 	// Connect Events
-	m_rbPredefined->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( AddSourceDlg::OnChangeType ), NULL, this );
-	m_rbCustom->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( AddSourceDlg::OnChangeType ), NULL, this );
-	m_cbChartSources->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( AddSourceDlg::OnSourceSelected ), NULL, this );
+	m_treeCtrl1->Connect( wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler( AddSourceDlg::OnSourceSelected ), NULL, this );
 	m_sdbSizerBtnsOK->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AddSourceDlg::OnOkClick ), NULL, this );
 }
 
 AddSourceDlg::~AddSourceDlg()
 {
 	// Disconnect Events
-	m_rbPredefined->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( AddSourceDlg::OnChangeType ), NULL, this );
-	m_rbCustom->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( AddSourceDlg::OnChangeType ), NULL, this );
-	m_cbChartSources->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( AddSourceDlg::OnSourceSelected ), NULL, this );
+	m_treeCtrl1->Disconnect( wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler( AddSourceDlg::OnSourceSelected ), NULL, this );
 	m_sdbSizerBtnsOK->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AddSourceDlg::OnOkClick ), NULL, this );
 	
 }

--- a/src/chartdldrgui.h
+++ b/src/chartdldrgui.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Jun  6 2014)
+// C++ code generated with wxFormBuilder (version Jun  5 2014)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -11,16 +11,20 @@
 #include <wx/artprov.h>
 #include <wx/xrc/xmlres.h>
 #include <wx/intl.h>
-#include <wx/string.h>
-#include <wx/radiobut.h>
+#include <wx/treectrl.h>
 #include <wx/gdicmn.h>
 #include <wx/font.h>
 #include <wx/colour.h>
 #include <wx/settings.h>
+#include <wx/string.h>
 #include <wx/sizer.h>
+#include <wx/panel.h>
+#include <wx/bitmap.h>
+#include <wx/image.h>
+#include <wx/icon.h>
 #include <wx/stattext.h>
-#include <wx/choice.h>
 #include <wx/textctrl.h>
+#include <wx/notebook.h>
 #include <wx/statbox.h>
 #include <wx/filepicker.h>
 #include <wx/button.h>
@@ -28,7 +32,6 @@
 #include <wx/listctrl.h>
 #include <wx/combobox.h>
 #include "checkedlistctrl.h"
-#include <wx/panel.h>
 #include <wx/checkbox.h>
 
 ///////////////////////////////////////////////////////////////////////////
@@ -42,9 +45,8 @@ class AddSourceDlg : public wxDialog
 	private:
 	
 	protected:
-		wxRadioButton* m_rbPredefined;
-		wxRadioButton* m_rbCustom;
-		wxStaticText* m_stCatalog;
+		wxPanel* m_panel1;
+		wxPanel* m_panel2;
 		wxStaticText* m_stName;
 		wxStaticText* m_stUrl;
 		wxStdDialogButtonSizer* m_sdbSizerBtns;
@@ -52,13 +54,13 @@ class AddSourceDlg : public wxDialog
 		wxButton* m_sdbSizerBtnsCancel;
 		
 		// Virtual event handlers, overide them in your derived class
-		virtual void OnChangeType( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnSourceSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnSourceSelected( wxTreeEvent& event ) { event.Skip(); }
 		virtual void OnOkClick( wxCommandEvent& event ) { event.Skip(); }
 		
 	
 	public:
-		wxChoice* m_cbChartSources;
+		wxNotebook* m_nbChoice;
+		wxTreeCtrl* m_treeCtrl1;
 		wxTextCtrl* m_tSourceName;
 		wxTextCtrl* m_tChartSourceUrl;
 		wxDirPickerCtrl* m_dpChartDirectory;


### PR DESCRIPTION
Hi Pavel,

As described in a previous email, this is a change proposal to implement wxTreeCtrl for Chart Source selection.
Works for me. Untested for Win platforms.

Using images may improve usage (to differentiate sections from catalogs)

I'm hesitating to use wxListCtrl with wxLC_ICON (instead of wxTreeCtrl used here) to ease navigation. It'd act as browsing your local disk, you'd navigate in the chart sources ; sections acting as folders and catalogs as final destination.

Please comment
